### PR TITLE
feat: agent configuration and minor tweaks

### DIFF
--- a/NewRelic.MAUI.Plugin/Shared/AgentStartConfiguration.cs
+++ b/NewRelic.MAUI.Plugin/Shared/AgentStartConfiguration.cs
@@ -1,0 +1,35 @@
+﻿using System;
+namespace Plugin.NRTest
+{
+	public enum LogLevel
+	{
+		ERROR,
+		WARNING,
+		INFO,
+		VERBOSE,
+		AUDIT
+	}
+
+	public class AgentStartConfiguration
+	{
+		public bool crashReportingEnabled = true;
+		public bool loggingEnabled = true;
+		public LogLevel logLevel = LogLevel.INFO;
+		public string collectorAddress = "DEFAULT";
+		public string crashCollectorAddress = "DEFAULT";
+		
+		public AgentStartConfiguration()
+		{
+		}
+
+		public AgentStartConfiguration(bool crashReportingEnabled, bool loggingEnabled, LogLevel logLevel, string collectorAddress, string crashCollectorAddress)
+		{
+			this.crashReportingEnabled = crashReportingEnabled;
+			this.loggingEnabled = loggingEnabled;
+			this.logLevel = logLevel;
+			this.collectorAddress = collectorAddress;
+			this.crashCollectorAddress = crashCollectorAddress;
+		}
+	}
+}
+

--- a/NewRelic.MAUI.Plugin/Shared/INewRelicMethods.cs
+++ b/NewRelic.MAUI.Plugin/Shared/INewRelicMethods.cs
@@ -7,7 +7,7 @@ namespace Plugin.NRTest
 {
 	public interface INewRelicMethods : IDisposable
     {
-        void Start(string applicationToken);
+        void Start(string applicationToken, AgentStartConfiguration agentConfig = null);
 
         void CrashNow(string message = "");
 

--- a/NewRelic.MAUI.Plugin/Shared/StackTraceParser.cs
+++ b/NewRelic.MAUI.Plugin/Shared/StackTraceParser.cs
@@ -101,8 +101,6 @@ namespace plugin.NRTest
         public static IEnumerable<NativeStackFrame> Parse(string stackTrace)
         {
             if (string.IsNullOrEmpty(stackTrace)) yield break;
-            Console.WriteLine("Maui Plugin" + stackTrace);
-            Console.WriteLine("Maui Plugin" + _regex.ToString());
 
             foreach (Match match in _regex.Matches(stackTrace))
             {

--- a/NewRelic.MAUI.iOS.Binding/ApiDefinition.cs
+++ b/NewRelic.MAUI.iOS.Binding/ApiDefinition.cs
@@ -231,6 +231,11 @@ namespace iOS.NewRelic
         [Export("setPlatform:")]
         void SetPlatform(NRMAApplicationPlatform platform);
 
+        // + (void) setPlatformVersion:(NSString * _Nonnull)platformVersion;
+        [Static]
+        [Export("setPlatformVersion:")]
+        void SetPlatformVersion(string platformVersion);
+
         // +(NSString * _Null_unspecified)currentSessionId;
         [Static]
         [Export("currentSessionId")]

--- a/README.md
+++ b/README.md
@@ -39,12 +39,19 @@ using Plugin.NRTest;
       MainPage = new AppShell();
       
       CrossNewRelic.Current.HandleUncaughtException();
+      // Set optional agent configuration
+      AgentStartConfiguration agentConfig = new AgentStartConfiguration(true, true, LogLevel.INFO, "mobile-collector.newrelic.com", "mobile-crash.newrelic.com");
+
       if (DeviceInfo.Current.Platform == DevicePlatform.Android) 
       {
-        CrossNewRelic.Current.Start("");
+        CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
+        // Start with optional agent configuration 
+        // CrossNewRelic.Current.Start("<APP-TOKEN-HERE", agentConfig);
       } else if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
       {
-        CrossNewRelic.Current.Start("");
+        CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
+        // Start with optional agent configuration 
+        // CrossNewRelic.Current.Start("<APP-TOKEN-HERE", agentConfig);
       }
     }
 
@@ -292,10 +299,10 @@ This plugin provides a handler to record unhandled exceptions to New Relic. It i
 
 ``` C#
     CrossNewRelic.Current.HandleUncaughtException();
-    if (Device.RuntimePlatform == Device.iOS)
+    if (DeviceInfo.Current.Platform == DevicePlatform.Android) 
     {
         CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
-    } else if (Device.RuntimePlatform == Device.Android)
+    } else if (DeviceInfo.Current.Platform == DevicePlatform.iOS)
     {
         CrossNewRelic.Current.Start("<APP-TOKEN-HERE>");
     }
@@ -316,7 +323,7 @@ This plugin also provides a method to manually record any handled exceptions as 
 ## Troubleshooting
 
 - ### No Http data appears:
-  - To instrument http data, make sure to use the HttpMessageHandler in HttpClient
+  - To instrument http data, make sure to use the HttpMessageHandler in HttpClient.
 
 ## Support
 


### PR DESCRIPTION
- Added agent configuration options on start
    - User can opt to not add `AgentStartConfiguration` object on start call for default settings
    - Default settings are all true, log level info, and default collector addresses
- Removed `Console.WriteLine(...)` from debugging
- Added default `HttpClientManager` to iOS since it will automatically instrument out of the box
- Added `SetPlatformVersion` to iOS binding and added set platform version on `Start`