### PR TITLE
feat: add shell navigation instrumentation

### DIFF
--- a/NewRelic.MAUI.Plugin/Platforms/Android/NewRelicMethodsImplementation.cs
+++ b/NewRelic.MAUI.Plugin/Platforms/Android/NewRelicMethodsImplementation.cs
@@ -70,7 +70,7 @@ public sealed class NewRelicMethodsImplementation : INewRelicMethods
             newRelic.UsingCrashCollectorAddress(agentConfig.crashCollectorAddress);
         }
 
-        newRelic.Start(Android.App.Application.Context);
+        newRelic.Start(global::Android.App.Application.Context);
 
         isStarted = true;
     }
@@ -301,6 +301,20 @@ public sealed class NewRelicMethodsImplementation : INewRelicMethods
         }
     }
 
+    public void TrackShellNavigatedEvents()
+    {
+        Shell.Current.Navigated += (sender, e) =>
+        {
+            Dictionary<string, object> attr = new Dictionary<string, object>();
+            if (e.Previous != null)
+            {
+                attr.Add("Previous", e.Previous.Location.ToString());
+            }
+            attr.Add("Current", e.Current.Location.ToString());
+            attr.Add("Source", e.Source.ToString());
+            this.RecordBreadcrumb("ShellNavigated", attr);
+        };
+    }
 
 
     public void Dispose()

--- a/NewRelic.MAUI.Plugin/Platforms/iOS/NewRelicMethodsImplementation.cs
+++ b/NewRelic.MAUI.Plugin/Platforms/iOS/NewRelicMethodsImplementation.cs
@@ -31,7 +31,7 @@ public class NewRelicMethodsImplementation : INewRelicMethods
 
         NRIosAgent.EnableCrashReporting(agentConfig.crashReportingEnabled);
         NRIosAgent.SetPlatform(iOS.NewRelic.NRMAApplicationPlatform.Xamarin);
-        iOS.NewRelic.NewRelic.SetPlatformVersion("dev");
+        iOS.NewRelic.NewRelic.SetPlatformVersion("0.0.1");
 
         iOS.NewRelic.NRLogger.SetLogLevels((uint)logLevelDict[agentConfig.logLevel]);
         if (!agentConfig.loggingEnabled)
@@ -264,6 +264,21 @@ public class NewRelicMethodsImplementation : INewRelicMethods
             };
         }
 
+    }
+
+    public void TrackShellNavigatedEvents()
+    {
+        Shell.Current.Navigated += (sender, e) =>
+        {
+            Dictionary<string, object> attr = new Dictionary<string, object>();
+            if (e.Previous != null)
+            {
+                attr.Add("Previous", e.Previous.Location.ToString());
+            }
+            attr.Add("Current", e.Current.Location.ToString());
+            attr.Add("Source", e.Source.ToString());
+            this.RecordBreadcrumb("ShellNavigated", attr);
+        };
     }
 
     public void Dispose()

--- a/NewRelic.MAUI.Plugin/Shared/INewRelicMethods.cs
+++ b/NewRelic.MAUI.Plugin/Shared/INewRelicMethods.cs
@@ -64,6 +64,8 @@ namespace NewRelic.MAUI.Plugin
 
         void HandleUncaughtException(bool shouldThrowFormattedException = true);
 
+        void TrackShellNavigatedEvents();
+
     }
 }
 

--- a/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
+++ b/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
@@ -45,7 +45,7 @@ namespace NewRelic.MAUI.Plugin
         // All exceptions will flow through Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser,
         // and NOT through AppDomain.CurrentDomain.UnhandledException
 
-        Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, args) =>
+        global::Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, args) =>
         {
             UnhandledException?.Invoke(sender, new UnhandledExceptionEventArgs(args.Exception, true));
         };

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ using NewRelic.MAUI.Plugin;
       MainPage = new AppShell();
       
       CrossNewRelic.Current.HandleUncaughtException();
+      CrossNewRelic.Current.TrackShellNavigatedEvents();
+
       // Set optional agent configuration
-      AgentStartConfiguration agentConfig = new AgentStartConfiguration(true, true, LogLevel.INFO, "mobile-collector.newrelic.com", "mobile-crash.newrelic.com");
+      // Options are: crashReportingEnabled, loggingEnabled, logLevel, collectorAddress, crashCollectorAddress
+      // AgentStartConfiguration agentConfig = new AgentStartConfiguration(true, true, LogLevel.INFO, "mobile-collector.newrelic.com", "mobile-crash.newrelic.com");
 
       if (DeviceInfo.Current.Platform == DevicePlatform.Android) 
       {
@@ -69,8 +72,22 @@ using NewRelic.MAUI.Plugin;
 
 ## Screen Tracking Events
 
-:construction: WORK IN PROGRESS :construction:
+The .NET MAUI mobile plugin allows you to track navigation events within the [.NET MAUI Shell](https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/shell/navigation). In order to do so, you only need to call:
 
+```C#
+    CrossNewRelic.Current.TrackShellNavigatedEvents();
+```
+
+It is recommended to call this method along when starting the agent. These events will only be recorded after navigation is complete. You can find this data through the data explorer in `MobileBreadcrumb` under the name `ShellNavigated` or by query:
+
+```sql
+    SELECT * FROM MobileBreadcrumb WHERE name = 'ShellNavigated' SINCE 24 HOURS AGO
+```
+
+The breadcrumb will contain three attributes:
+* `Current`: The URI of the current page.
+* `Source`: The type of navigation that occurred.
+* `Previous`: The URI of the previous page. Will not exist if previous page was null. 
 
 ## Usage
 


### PR DESCRIPTION
This PR uses shell navigated event handler and adds a `ShellNavigated` breadcrumb with the data in the `ShellNavigatedEventArgs` object in the `Navigated` event. It will record a breadcrumb _**after**_ a navigation event has occurred. It will contain the URI of current page, URI of previous page (none if on first load or is null), and the source of the navigation. 