### PR TITLE
tests: Add initial testing framework

### DIFF
--- a/NewRelic.MAUI.Plugin.Tests/INewRelicMethodsTest.cs
+++ b/NewRelic.MAUI.Plugin.Tests/INewRelicMethodsTest.cs
@@ -1,0 +1,261 @@
+﻿using NewRelic.MAUI.Plugin;
+using NUnit.Framework;
+using Moq;
+
+namespace NewRelic.MAUI.Plugin.Tests;
+
+[TestFixture]
+public class INewRelicMethodsTest
+{
+    Mock<INewRelicMethods> newRelicMethodsMock;
+    NewRelicMethodsMock newRelicMockScope;
+
+    [SetUp]
+    public void Setup()
+    {
+        newRelicMethodsMock = new Mock<INewRelicMethods>();
+        newRelicMockScope = new NewRelicMethodsMock(newRelicMethodsMock.Object);
+    }
+
+    [Test]
+    public void TestStart()
+    {
+        CrossNewRelic.Current.Start("<app-token>");
+        AgentStartConfiguration asc = new AgentStartConfiguration();
+        CrossNewRelic.Current.Start("<app-token-2>", asc);
+        newRelicMethodsMock.Verify(methods => methods.Start("<app-token>", null), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.Start("<app-token-2>", asc), Times.Once);
+    }
+
+
+    [Test]
+    public void TestCrashNow()
+    {
+        CrossNewRelic.Current.CrashNow();
+        CrossNewRelic.Current.CrashNow("Example crash");
+        newRelicMethodsMock.Verify(methods => methods.CrashNow(""), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.CrashNow("Example crash"), Times.Once);
+    }
+
+    [Test]
+    public void TestCurrentSessionId()
+    {
+        string id = CrossNewRelic.Current.CurrentSessionId();
+        newRelicMethodsMock.Verify(methods => methods.CurrentSessionId(), Times.Once);
+    }
+
+    [Test]
+    public void TestStartInteraction()
+    {
+        string id = CrossNewRelic.Current.StartInteraction("interactionName");
+        newRelicMethodsMock.Verify(methods => methods.StartInteraction("interactionName"), Times.Once);
+    }
+
+    [Test]
+    public void TestEndInteraction()
+    {
+        CrossNewRelic.Current.EndInteraction("interactionId");
+        newRelicMethodsMock.Verify(methods => methods.EndInteraction("interactionId"), Times.Once);
+    }
+
+    [Test]
+    public void TestNoticeHttpTransaction()
+    {
+        CrossNewRelic.Current.NoticeHttpTransaction(
+            "https://newrelic.com",
+            "GET",
+            200,
+            10000,
+            10001,
+            0,
+            100,
+            "");
+        newRelicMethodsMock.Verify(methods => methods.NoticeHttpTransaction(
+            "https://newrelic.com",
+            "GET",
+            200,
+            10000,
+            10001,
+            0,
+            100,
+            ""), Times.Once);
+    }
+
+    [Test]
+    public void TestNoticeNetworkFailure()
+    {
+        CrossNewRelic.Current.NoticeNetworkFailure(
+            "https://fakewebsite.com",
+            "POST",
+            10000,
+            10001,
+            NetworkFailure.Unknown);
+        newRelicMethodsMock.Verify(methods => methods.NoticeNetworkFailure(
+            "https://fakewebsite.com",
+            "POST",
+            10000,
+            10001,
+            NetworkFailure.Unknown), Times.Once);
+    }
+
+    [Test]
+    public void TestRecordBreadcrumb()
+    {
+        Dictionary<string, object> attr = new Dictionary<string, object>()
+        {
+            { "attr1", 1 },
+            { "attr2", "2" },
+            { "attr3", false }
+        };
+        CrossNewRelic.Current.RecordBreadcrumb("Breadname", attr);
+        newRelicMethodsMock.Verify(methods => methods.RecordBreadcrumb("Breadname", attr), Times.Once);
+    }
+
+    [Test]
+    public void TestRecordCustomEvent()
+    {
+        Dictionary<string, object> attr = new Dictionary<string, object>()
+        {
+            { "attr1", 1 },
+            { "attr2", "2" },
+            { "attr3", false }
+        };
+        CrossNewRelic.Current.RecordCustomEvent("EventType", "EventName", attr);
+        newRelicMethodsMock.Verify(methods => methods.RecordCustomEvent("EventType", "EventName", attr), Times.Once);
+    }
+
+    [Test]
+    public void TestRecordMetric()
+    {
+        CrossNewRelic.Current.RecordMetric("Metric0", "TestMetric");
+        CrossNewRelic.Current.RecordMetric("Metric1", "TestMetric", 12.3);
+        CrossNewRelic.Current.RecordMetric("Metric2", "TestMetric", 45.6, MetricUnit.PERCENT, MetricUnit.BYTES_PER_SECOND);
+
+        newRelicMethodsMock.Verify(methods => methods.RecordMetric("Metric0", "TestMetric"), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.RecordMetric("Metric1", "TestMetric", 12.3), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.RecordMetric("Metric2", "TestMetric", 45.6, MetricUnit.PERCENT, MetricUnit.BYTES_PER_SECOND), Times.Once);
+    }
+
+    [Test]
+    public void TestSetAttribute()
+    {
+        CrossNewRelic.Current.SetAttribute("StrAttr", "MAUIAttr");
+        CrossNewRelic.Current.SetAttribute("BoolAttr", true);
+        CrossNewRelic.Current.SetAttribute("NumAttr", 78.9);
+
+        newRelicMethodsMock.Verify(methods => methods.SetAttribute("StrAttr", "MAUIAttr"), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.SetAttribute("BoolAttr", true), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.SetAttribute("NumAttr", 78.9), Times.Once);
+    }
+
+    [Test]
+    public void TestIncrementAttribute()
+    {
+        CrossNewRelic.Current.IncrementAttribute("NumAttr");
+        CrossNewRelic.Current.IncrementAttribute("NumAttr", 3);
+
+        newRelicMethodsMock.Verify(methods => methods.IncrementAttribute("NumAttr", 1), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.IncrementAttribute("NumAttr", 3), Times.Once);
+    }
+
+    [Test]
+    public void TestRemoveAttribute()
+    {
+        CrossNewRelic.Current.RemoveAttribute("NumAttr");
+        newRelicMethodsMock.Verify(methods => methods.RemoveAttribute("NumAttr"), Times.Once);
+    }
+
+    [Test]
+    public void TestRemoveAllAttributes()
+    {
+        CrossNewRelic.Current.RemoveAllAttributes();
+        newRelicMethodsMock.Verify(methods => methods.RemoveAllAttributes(), Times.Once);
+    }
+
+    [Test]
+    public void TestSetMaxEventBufferTime()
+    {
+        CrossNewRelic.Current.SetMaxEventBufferTime(120);
+        newRelicMethodsMock.Verify(methods => methods.SetMaxEventBufferTime(120), Times.Once);
+    }
+
+    [Test]
+    public void TestSetMaxEventPoolSize()
+    {
+        CrossNewRelic.Current.SetMaxEventPoolSize(1200);
+        newRelicMethodsMock.Verify(methods => methods.SetMaxEventPoolSize(1200), Times.Once);
+    }
+
+    [Test]
+    public void TestSetUserId()
+    {
+        CrossNewRelic.Current.SetUserId("abc");
+        newRelicMethodsMock.Verify(methods => methods.SetUserId("abc"), Times.Once);
+    }
+
+    [Test]
+    public void TestAnalyticsEventEnabled()
+    {
+        CrossNewRelic.Current.AnalyticsEventEnabled(true);
+        newRelicMethodsMock.Verify(methods => methods.AnalyticsEventEnabled(true), Times.Once);
+    }
+
+    [Test]
+    public void TestNetworkRequestEnabled()
+    {
+        CrossNewRelic.Current.NetworkRequestEnabled(true);
+        newRelicMethodsMock.Verify(methods => methods.NetworkRequestEnabled(true), Times.Once);
+    }
+
+    [Test]
+    public void TestNetworkErrorRequestEnabled()
+    {
+        CrossNewRelic.Current.NetworkErrorRequestEnabled(true);
+        newRelicMethodsMock.Verify(methods => methods.NetworkErrorRequestEnabled(true), Times.Once);
+    }
+
+    [Test]
+    public void TestHttpResponseBodyCaptureEnabled()
+    {
+        CrossNewRelic.Current.HttpResponseBodyCaptureEnabled(true);
+        newRelicMethodsMock.Verify(methods => methods.HttpResponseBodyCaptureEnabled(true), Times.Once);
+    }
+
+    [Test]
+    public void TestRecordException()
+    {
+        Exception testException = new Exception("test exception");
+        CrossNewRelic.Current.RecordException(testException);
+        newRelicMethodsMock.Verify(methods => methods.RecordException(testException), Times.Once);
+    }
+
+    [Test]
+    public void TestGetHttpMessageHandler()
+    {
+        HttpMessageHandler httpMessageHandler = CrossNewRelic.Current.GetHttpMessageHandler();
+        newRelicMethodsMock.Verify(methods => methods.GetHttpMessageHandler(), Times.Once);
+    }
+
+    [Test]
+    public void TestHandleUncaughtException()
+    {
+        CrossNewRelic.Current.HandleUncaughtException();
+        CrossNewRelic.Current.HandleUncaughtException(false);
+        newRelicMethodsMock.Verify(methods => methods.HandleUncaughtException(true), Times.Once);
+        newRelicMethodsMock.Verify(methods => methods.HandleUncaughtException(false), Times.Once);
+    }
+
+    [Test]
+    public void TestTrackShellNavigatedEvents()
+    {
+        CrossNewRelic.Current.TrackShellNavigatedEvents();
+        newRelicMethodsMock.Verify(methods => methods.TrackShellNavigatedEvents(), Times.Once);
+    }
+
+    [Test]
+    public void TestShutdown()
+    {
+        CrossNewRelic.Current.Shutdown();
+        newRelicMethodsMock.Verify(methods => methods.Shutdown(), Times.Once);
+    }
+}

--- a/NewRelic.MAUI.Plugin.Tests/NewRelic.MAUI.Plugin.Tests.csproj
+++ b/NewRelic.MAUI.Plugin.Tests/NewRelic.MAUI.Plugin.Tests.csproj
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project Sdk="Microsoft.NET.Sdk">
+	<PropertyGroup>
+		<TargetFramework>net7.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+		<IsPackable>false</IsPackable>
+		<IsTestProject>true</IsTestProject>
+	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+		<PackageReference Include="NUnit.Analyzers" Version="3.6.1" />
+		<PackageReference Include="coverlet.collector" Version="6.0.0">
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+			<PrivateAssets>all</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Moq" Version="4.18.4" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\NewRelic.MAUI.Plugin\NewRelic.MAUI.Plugin.csproj" />
+	</ItemGroup>
+</Project>

--- a/NewRelic.MAUI.Plugin.Tests/NewRelicMethodsMock.cs
+++ b/NewRelic.MAUI.Plugin.Tests/NewRelicMethodsMock.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Reflection;
+using NewRelic.MAUI.Plugin;
+
+internal class NewRelicMethodsMock : IDisposable
+{
+    private readonly Lazy<INewRelicMethods> _originalInstance;
+
+    public NewRelicMethodsMock(INewRelicMethods mockImplementation)
+    {
+        _originalInstance = GetImplementation();
+        SetImplementation(new Lazy<INewRelicMethods>(() => mockImplementation, System.Threading.LazyThreadSafetyMode.PublicationOnly));
+    }
+
+    public void Dispose()
+    {
+        SetImplementation(_originalInstance);
+    }
+
+    private static Lazy<INewRelicMethods> GetImplementation()
+    {
+        var field = typeof(CrossNewRelic).GetField("_implementation", BindingFlags.Static | BindingFlags.NonPublic);
+        return (Lazy<INewRelicMethods>)field.GetValue(null);
+    }
+
+    private static void SetImplementation(Lazy<INewRelicMethods> implementation)
+    {
+        var field = typeof(CrossNewRelic).GetField("_implementation", BindingFlags.Static | BindingFlags.NonPublic);
+        field.SetValue(null, implementation);
+    }
+}
+

--- a/NewRelic.MAUI.Plugin.Tests/Usings.cs
+++ b/NewRelic.MAUI.Plugin.Tests/Usings.cs
@@ -1,0 +1,1 @@
+﻿global using NUnit.Framework;

--- a/newrelic-maui-plugin.sln
+++ b/newrelic-maui-plugin.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NewRelic.MAUI.Android.Bindi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NewRelic.MAUI.iOS.Binding", "NewRelic.MAUI.iOS.Binding\NewRelic.MAUI.iOS.Binding.csproj", "{C9974FDF-099E-4FC5-B702-EB29C98EFE84}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NewRelic.MAUI.Plugin.Tests", "NewRelic.MAUI.Plugin.Tests\NewRelic.MAUI.Plugin.Tests.csproj", "{91C585A7-F7FA-42BA-979F-3E52EA06FF0C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{C9974FDF-099E-4FC5-B702-EB29C98EFE84}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9974FDF-099E-4FC5-B702-EB29C98EFE84}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9974FDF-099E-4FC5-B702-EB29C98EFE84}.Release|Any CPU.Build.0 = Release|Any CPU
+		{91C585A7-F7FA-42BA-979F-3E52EA06FF0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{91C585A7-F7FA-42BA-979F-3E52EA06FF0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{91C585A7-F7FA-42BA-979F-3E52EA06FF0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{91C585A7-F7FA-42BA-979F-3E52EA06FF0C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Adds NUnit testing framework in a separate `NewRelic.MAUI.Plugin.Tests` project
   - Created mock for INewRelicMethods by creating a reflection
       - Methods implementation will be null in mock
   - Basic tests confirming that the API will be able to be called with the correct parameters