### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -8,6 +8,9 @@ name: Repolinter Action
 # filtered in the "Test Default Branch" step.
 on: [push, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   repolint:
     name: Run Repolinter


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-maui-plugin/security/code-scanning/11](https://github.com/newrelic/newrelic-maui-plugin/security/code-scanning/11)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default. The best fix here is to define it at the workflow root (applies to all jobs unless overridden), starting with `contents: read`, which satisfies checkout/read operations and CodeQL’s minimal recommendation without changing intended behavior.

Edit **`.github/workflows/repolinter.yml`** near the top-level keys (after `on:` and before `jobs:`), adding:

- `permissions:`
  - `contents: read`

No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
