### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: read
+
 env:
   DOTNET_VERSION: '9.0.x'
 


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-maui-plugin/security/code-scanning/12](https://github.com/newrelic/newrelic-maui-plugin/security/code-scanning/12)

Add an explicit top-level `permissions` block in `.github/workflows/release.yml` so all jobs inherit least-privilege defaults.  
Best single fix: define minimal read access globally:

- `contents: read` (needed for checkout and repository content reads)
- `packages: read` (safe baseline commonly recommended by GitHub/CodeQL guidance)

This should be inserted near the top-level keys (right after `on:` block and before `env:` is a clean location).  
No imports, methods, or extra dependencies are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
