### PR TITLE
[MAUI] Add net11 (CoreCLR) targets, drop net9 [hold: net11 GA]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+## Changes
+
+- Dropped .NET 9 target frameworks (`net9.0`, `net9.0-android`, `net9.0-ios`). .NET 9 is a Standard Term Support (STS) release reaching end of support on November 10, 2026; the minimum supported framework is now .NET 10 (LTS).
+
 # 1.2.4
 
 ## Improvements

--- a/NewRelic.MAUI.Android.Binding/NewRelic.MAUI.Android.Binding.csproj
+++ b/NewRelic.MAUI.Android.Binding/NewRelic.MAUI.Android.Binding.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android;net10.0-android</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net11.0-android</TargetFrameworks>
 		<SupportedOSPlatformVersion>24</SupportedOSPlatformVersion>
 		<!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here. -->
 		<NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>

--- a/NewRelic.MAUI.Plugin.Tests/NewRelic.MAUI.Plugin.Tests.csproj
+++ b/NewRelic.MAUI.Plugin.Tests/NewRelic.MAUI.Plugin.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net11.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/NewRelic.MAUI.Plugin/NewRelic.MAUI.Plugin.csproj
+++ b/NewRelic.MAUI.Plugin/NewRelic.MAUI.Plugin.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net10.0;net10.0-android;net10.0-ios</TargetFrameworks>
+		<TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net11.0;net11.0-android;net11.0-ios</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
@@ -31,22 +31,25 @@
 	<ItemGroup>
 		<Folder Include="Shared\" />
 	</ItemGroup>
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
-	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
 		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.1" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
-	  <PackageReference Include="NewRelic.MAUI.iOS.Binding" Version="7.7.2" />
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net11.0'))">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="11.0.0-preview.5.26304.4" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
 	  <PackageReference Include="NewRelic.MAUI.iOS.Binding" Version="7.7.2" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
 	  <PackageReference Include="NewRelic.MAUI.Android.Binding" Version="7.7.6" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
-	  <PackageReference Include="NewRelic.MAUI.Android.Binding" Version="7.7.6" />
+	<!-- net11: published binding NuGet packages don't ship net11 assets yet, so build the
+	     binding projects from source via ProjectReference for local CoreCLR (.NET 11) validation.
+	     Publishing net11 binding packages is the release follow-up (see NR-566721). -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net11.0-ios'">
+	  <ProjectReference Include="..\NewRelic.MAUI.iOS.Binding\NewRelic.MAUI.iOS.Binding.csproj" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net11.0-android'">
+	  <ProjectReference Include="..\NewRelic.MAUI.Android.Binding\NewRelic.MAUI.Android.Binding.csproj" />
 	</ItemGroup>
 </Project>

--- a/NewRelic.MAUI.iOS.Binding/NewRelic.MAUI.iOS.Binding.csproj
+++ b/NewRelic.MAUI.iOS.Binding/NewRelic.MAUI.iOS.Binding.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+		<TargetFrameworks>net10.0-ios;net11.0-ios</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>true</ImplicitUsings>
 		<PackageId>NewRelic.MAUI.iOS.Binding</PackageId>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This plugin allows you to instrument .NET MAUI mobile apps with help of native N
 ## Current Support:
 
 This project targets .NET MAUI mobile apps and supports .NET MAUI [minimum supported platforms](https://learn.microsoft.com/en-us/dotnet/maui/supported-platforms):
+- Requires .NET 10 (LTS) or higher — the .NET 9 (STS) targets have been dropped
 - Android 7.0 (API 24) or higher
 - iOS 16 or higher, using the latest release of Xcode
 - Depends on New Relic iOS/XCFramework and Android agents


### PR DESCRIPTION
## ⚠️ DRAFT — hold until .NET 11 GA (or a decision to ship net11 as prerelease)

Part of the MAUI-on-CoreCLR (.NET 11) transition (NR-566721). **Do not merge while net11 is preview**, because it:
- makes `main` depend on the **preview** net11 SDK and `Microsoft.Maui.Controls 11.0.0-preview.5`;
- wires the net11 bindings via `ProjectReference` (published net11 binding packages don't exist yet → **NR-587401**);
- can't be built/packed by the current release pipeline, which isn't on the net11 SDK/toolchain yet → **NR-587402**.

Merge once net11 is GA and NR-587401 (publish net11 binding packages) + NR-587402 (CI) have landed — or re-scope to publish net11 as prerelease if we decide to ship during preview.

## What this changes
`main` today targets **net9 + net10** (no net11 anywhere). This PR:
- **Introduces net11** (`net11.0`, `net11.0-android`, `net11.0-ios`) across plugin + bindings + tests, with net11 bindings via temporary `ProjectReference` (see NR-587401) and `Maui.Controls 11.0.0-preview.5`.
- **Drops net9** (`net9.0`, `net9.0-android`, `net9.0-ios`) — NR-587400. Under the net11 SDK the net9 MAUI workloads are flagged out of support (`NETSDK1202`, per [maui-support-policy](https://aka.ms/maui-support-policy)), which blocks restore/build for every TFM unless `-p:CheckEolWorkloads=false` is passed. Minimum supported framework becomes .NET 10 (LTS).
- Updates CHANGELOG / README.

## Target frameworks
| Project | main (today) | this PR |
|---|---|---|
| Plugin | net9.0/-android/-ios; net10.0/-android/-ios | net10.0/-android/-ios; net11.0/-android/-ios |
| iOS binding | net9.0-ios; net10.0-ios | net10.0-ios; net11.0-ios |
| Android binding | net9.0-android; net10.0-android | net10.0-android; net11.0-android |
| Tests | net9.0; net10.0 | net10.0; net11.0 |

## Verification (net9 drop / NETSDK1202)
Controlled before/after under the net11 SDK (`11.0.100-preview.5`), same command, **no** `CheckEolWorkloads` flag:

| State | `net10.0` | `net11.0` |
|---|---|---|
| net9 present (main) | ❌ EXIT 1, NETSDK1202 | ❌ EXIT 1, NETSDK1202 |
| net9 dropped (this PR) | ✅ succeeded, 0 NETSDK1202 | ✅ succeeded, 0 NETSDK1202 |

Jira: NR-587400 (follow-ups: NR-587401 publish net11 packages, NR-587402 CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
