### PR TITLE
[MAUI] Capture iOS unhandled exceptions under CoreCLR (.NET 11) [hold: net11 GA]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+## Bug Fixes
+
+- Fixed iOS unhandled exceptions losing their managed (C#) context under CoreCLR (.NET 10+). `AppDomain.CurrentDomain.UnhandledException` no longer fires for exceptions that unwind through native code, so an unhandled managed exception was reported only as a native crash with no C# stack. The plugin now also captures it at the `ObjCRuntime.Runtime.MarshalManagedException` boundary and reports it as a handled exception with its stack trace (matching Android), with a guard so Mono (net10) does not double-report.
+
 # 1.2.4
 
 ## Improvements

--- a/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
+++ b/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
@@ -12,6 +12,11 @@ namespace NewRelic.MAUI.Plugin
     private static Exception _lastFirstChanceException;
 #endif
 
+        // Guards against reporting the same unhandled exception twice when more than one hook
+        // fires for it (on Mono both AppDomain.CurrentDomain.UnhandledException and
+        // ObjCRuntime.Runtime.MarshalManagedException fire for the same iOS exception). (NR-588069)
+        private static Exception _lastReportedException;
+
         // We'll route all unhandled exceptions through this one event.
         public static event UnhandledExceptionEventHandler UnhandledException;
 
@@ -23,19 +28,38 @@ namespace NewRelic.MAUI.Plugin
 
             AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
             {
+                if (args.ExceptionObject is Exception ex)
+                {
+                    if (ReferenceEquals(ex, _lastReportedException))
+                    {
+                        return;
+                    }
+                    _lastReportedException = ex;
+                }
                 UnhandledException?.Invoke(sender, args);
             };
 
 #if IOS || MACCATALYST
 
-        // For iOS and Mac Catalyst
-        // Exceptions will flow through AppDomain.CurrentDomain.UnhandledException,
-        // but we need to set UnwindNativeCode to get it to work correctly. 
-        // 
+        // For iOS and Mac Catalyst:
+        //
+        // On Mono, unhandled exceptions flowed through AppDomain.CurrentDomain.UnhandledException
+        // (we set UnwindNativeCode below to make that work).
         // See: https://github.com/xamarin/xamarin-macios/issues/15252
-        
+        //
+        // Under CoreCLR (.NET 10+), AppDomain.CurrentDomain.UnhandledException no longer fires for
+        // exceptions that unwind through native code, so we also capture the exception here at the
+        // managed->native boundary, where CoreCLR surfaces it (args.Exception is populated). Verified
+        // on-device: for an unhandled managed exception only MarshalManagedException fires, not AppDomain.
+        // See: https://learn.microsoft.com/en-us/dotnet/ios/advanced-concepts/exception-marshaling (NR-588069)
         ObjCRuntime.Runtime.MarshalManagedException += (_, args) =>
         {
+            if (args.Exception is not null && !ReferenceEquals(args.Exception, _lastReportedException))
+            {
+                _lastReportedException = args.Exception;
+                UnhandledException?.Invoke(null, new UnhandledExceptionEventArgs(args.Exception, true));
+            }
+
             args.ExceptionMode = ObjCRuntime.MarshalManagedExceptionMode.UnwindNativeCode;
         };
 


### PR DESCRIPTION
## ⚠️ DRAFT — hold to land with the net11 enablement

This fixes a bug that **only manifests on net11/CoreCLR**, which `main` does not target yet (main is net9 + net10). On the current net10-only release the fix is **dormant and behavior-neutral** (on Mono both hooks fire and the dedup yields a single report — same outcome as today). So there's no interim benefit to changing shipping exception-handling code ahead of net11 — this should land **together with the net11 target-frameworks enablement** (the net11 GA cutover), not before.

It is technically safe to merge now if desired; it's held only because its payoff is entirely on net11.

## Summary

Under CoreCLR (.NET 10+), `AppDomain.CurrentDomain.UnhandledException` no longer fires for managed exceptions that unwind through native code. On iOS the plugin relied solely on that event, so an unhandled managed exception produced only a native `MobileCrash` (`crashMessage=null`, no managed context) — whereas Android reports it as a handled exception with the C# stack.

This captures the exception at the `ObjCRuntime.Runtime.MarshalManagedException` boundary (where CoreCLR surfaces it — `args.Exception` populated) and routes it through the existing `MauiExceptions.UnhandledException` event → `RecordException`, matching Android. A `ReferenceEquals` dedup guard shared with the `AppDomain` handler prevents a double-report on Mono (net10), where both hooks fire for the same exception instance.

## Change
- `Shared/MauiExceptions.cs`: iOS `MarshalManagedException` handler now invokes `UnhandledException` with `args.Exception`; the `AppDomain` + Marshal handlers share a `_lastReportedException` dedup guard.

## Verification (net11/CoreCLR)
| Check | Result |
|---|---|
| Root cause: only `MarshalManagedException` fires on CoreCLR, not `AppDomain` | confirmed (sim + MS docs) |
| Fix routes unhandled exception → `RecordException` | ✅ simulator |
| No double-report on net10/Mono | ✅ simulator (dedup → single report) |
| Persists across abort + uploads to staging | ✅ agent log, `200` |
| Lands in staging as `MobileHandledException` with managed context | ✅ |

Real-device Release (iPhone18,3, iOS 26.2.1): `MobileHandledException`, `hasStackTrace=true`, managed class/method captured. (`file:line` is `<unknown>` on Release — expected, no PDBs shipped; see NR-587399.)

Jira: NR-588069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
