### PR TITLE
[MAUI] CI: build/pack net11 target frameworks [hold: net11 GA]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,11 @@ permissions:
   packages: read
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  # net11 mobile targets need the .NET 11 SDK; the plugin/bindings also still target
+  # net10, so install both. net11 is pinned to the validated preview for now — bump to
+  # the GA SDK when net11 ships (tracked by NR-587402).
+  DOTNET_VERSION_NET10: '10.0.x'
+  DOTNET_VERSION_NET11: '11.0.100-preview.5.26302.115'
 
 jobs:
   parse-tag:
@@ -83,13 +87,29 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            ${{ env.DOTNET_VERSION_NET10 }}
+            ${{ env.DOTNET_VERSION_NET11 }}
+
+      - name: Select Xcode 26.5 (required by the .NET 11 iOS workload; a mismatch is a hard build error)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.5'
+
+      - name: Setup JDK 21 (required by .NET 11 Android tooling; clears XA0033)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
 
       - name: Install workloads
         run: |
           dotnet workload install maui
           dotnet workload install ios
           dotnet workload install android
+
+      - name: Install Android API 37 platform (required by the .NET 11 Android targets)
+        run: ${ANDROID_HOME:-$ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "platforms;android-37"
 
       - name: Run release script
         env:


### PR DESCRIPTION
## ⚠️ DRAFT — hold until net11 GA (runner toolchain)

Prep `release.yml` to build + pack the net11 (CoreCLR) target frameworks. Part of the MAUI-on-CoreCLR transition (NR-566721); it depends on the net11 enablement (NR-587400) and unblocks publishing the net11 binding packages (NR-587401).

**Not verifiable green yet:** hosted `macos-latest` runners won't reliably have the net11 preview SDK or **Xcode 26.5** until net11 matures, so this is staged and held for GA (the exact SDK/Xcode/JDK/API versions settle then).

## Changes (`.github/workflows/release.yml`)
- **SDK:** `9.0.x` → install **both** `10.0.x` and the net11 preview (`11.0.100-preview.5…`) via `setup-dotnet` (plugin + bindings multi-target net10 **and** net11).
- **Xcode:** add `maxim-lobanov/setup-xcode@v1` pinned to **26.5** — the net11 iOS workload requires it; a mismatch is a hard build error (hit locally with Xcode 27 beta).
- **JDK:** add `actions/setup-java` **temurin 21** — net11 Android tooling rejects JDK 17 (`XA0033`).
- **Android:** install the **API 37** platform via `sdkmanager` (required by net11 Android targets).

## At GA
- bump the net11 SDK pin to the GA version;
- confirm the runner image provides Xcode 26.5 (or whatever the GA workload requires);
- do one dry-run release to confirm net11 iOS + Android build/pack with no `XA0033` and no Xcode mismatch.

Jira: NR-587402

🤖 Generated with [Claude Code](https://claude.com/claude-code)
