### PR TITLE
[MAUI] net11 (CoreCLR) support cutover — drop net9, iOS exception capture, CI [hold: net11 GA]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,11 @@ permissions:
   packages: read
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  # net11 mobile targets need the .NET 11 SDK; the plugin/bindings also still target
+  # net10, so install both. net11 is pinned to the validated preview for now — bump to
+  # the GA SDK when net11 ships (tracked by NR-587402).
+  DOTNET_VERSION_NET10: '10.0.x'
+  DOTNET_VERSION_NET11: '11.0.100-preview.5.26302.115'
 
 jobs:
   parse-tag:
@@ -83,13 +87,29 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          dotnet-version: |
+            ${{ env.DOTNET_VERSION_NET10 }}
+            ${{ env.DOTNET_VERSION_NET11 }}
+
+      - name: Select Xcode 26.5 (required by the .NET 11 iOS workload; a mismatch is a hard build error)
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.5'
+
+      - name: Setup JDK 21 (required by .NET 11 Android tooling; clears XA0033)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
 
       - name: Install workloads
         run: |
           dotnet workload install maui
           dotnet workload install ios
           dotnet workload install android
+
+      - name: Install Android API 37 platform (required by the .NET 11 Android targets)
+        run: ${ANDROID_HOME:-$ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager "platforms;android-37"
 
       - name: Run release script
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,17 @@ jobs:
         with:
           xcode-version: '26.5'
 
-      - name: Setup JDK 21 (required by .NET 11 Android tooling; clears XA0033)
+      # JDK 17, not 21: JDK 21 clears the cosmetic XA0033 warning but triggers a real runtime
+      # bug under CoreCLR on Android -- Java.Interop fails to resolve bound-enum Java types
+      # (ArgumentException: "Could not determine Java type corresponding to ...") and the
+      # agent never starts. JDK 17 has the cosmetic XA0033 but the app/agent runs correctly.
+      # Verified by isolated A/B (same SDK/TFM/device, only JDK changed). Revisit once the
+      # upstream .NET-for-Android/Java.Interop issue is fixed. Tracked by NR-587401.
+      - name: Setup JDK 17 (net11 Android + CoreCLR; JDK 21 breaks agent startup -- see comment)
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
 
       - name: Install workloads
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+## Bug Fixes
+
+- Fixed iOS unhandled exceptions losing their managed (C#) context under CoreCLR (.NET 10+). `AppDomain.CurrentDomain.UnhandledException` no longer fires for exceptions that unwind through native code, so an unhandled managed exception was reported only as a native crash with no C# stack. The plugin now also captures it at the `ObjCRuntime.Runtime.MarshalManagedException` boundary and reports it as a handled exception with its stack trace (matching Android), with a guard so Mono (net10) does not double-report.
+
 # 1.2.4
 
 ## Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+## Changes
+
+- Dropped .NET 9 target frameworks (`net9.0`, `net9.0-android`, `net9.0-ios`). .NET 9 is a Standard Term Support (STS) release reaching end of support on November 10, 2026; the minimum supported framework is now .NET 10 (LTS).
+
 # 1.2.4
 
 ## Improvements

--- a/NewRelic.MAUI.Android.Binding/NewRelic.MAUI.Android.Binding.csproj
+++ b/NewRelic.MAUI.Android.Binding/NewRelic.MAUI.Android.Binding.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-android;net10.0-android</TargetFrameworks>
+		<TargetFrameworks>net10.0-android;net11.0-android</TargetFrameworks>
 		<SupportedOSPlatformVersion>24</SupportedOSPlatformVersion>
 		<!-- BG8605 and BG8606 happen because there's a missing androidx.lifecycle dependency, but we don't need it here. -->
 		<NoWarn>$(NoWarn);BG8605;BG8606</NoWarn>

--- a/NewRelic.MAUI.Plugin.Tests/NewRelic.MAUI.Plugin.Tests.csproj
+++ b/NewRelic.MAUI.Plugin.Tests/NewRelic.MAUI.Plugin.Tests.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+		<TargetFrameworks>net10.0;net11.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<IsPackable>false</IsPackable>

--- a/NewRelic.MAUI.Plugin/NewRelic.MAUI.Plugin.csproj
+++ b/NewRelic.MAUI.Plugin/NewRelic.MAUI.Plugin.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0;net9.0-android;net9.0-ios;net10.0;net10.0-android;net10.0-ios</TargetFrameworks>
+		<TargetFrameworks>net10.0;net10.0-android;net10.0-ios;net11.0;net11.0-android;net11.0-ios</TargetFrameworks>
 		<!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
 		<!-- <TargetFrameworks>$(TargetFrameworks);net7.0-tizen</TargetFrameworks> -->
 		<UseMaui>true</UseMaui>
@@ -31,22 +31,25 @@
 	<ItemGroup>
 		<Folder Include="Shared\" />
 	</ItemGroup>
-	<ItemGroup Condition="$(TargetFramework.StartsWith('net9.0'))">
-		<PackageReference Include="Microsoft.Maui.Controls" Version="9.0.120" />
-	</ItemGroup>
 	<ItemGroup Condition="$(TargetFramework.StartsWith('net10.0'))">
 		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.1" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
-	  <PackageReference Include="NewRelic.MAUI.iOS.Binding" Version="7.7.2" />
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net11.0'))">
+		<PackageReference Include="Microsoft.Maui.Controls" Version="11.0.0-preview.5.26304.4" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-ios'">
+	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-ios'">
 	  <PackageReference Include="NewRelic.MAUI.iOS.Binding" Version="7.7.2" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net10.0-android'">
 	  <PackageReference Include="NewRelic.MAUI.Android.Binding" Version="7.7.6" />
 	</ItemGroup>
-	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">
-	  <PackageReference Include="NewRelic.MAUI.Android.Binding" Version="7.7.6" />
+	<!-- net11: published binding NuGet packages don't ship net11 assets yet, so build the
+	     binding projects from source via ProjectReference for local CoreCLR (.NET 11) validation.
+	     Publishing net11 binding packages is the release follow-up (see NR-566721). -->
+	<ItemGroup Condition="'$(TargetFramework)' == 'net11.0-ios'">
+	  <ProjectReference Include="..\NewRelic.MAUI.iOS.Binding\NewRelic.MAUI.iOS.Binding.csproj" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net11.0-android'">
+	  <ProjectReference Include="..\NewRelic.MAUI.Android.Binding\NewRelic.MAUI.Android.Binding.csproj" />
 	</ItemGroup>
 </Project>

--- a/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
+++ b/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
@@ -12,6 +12,11 @@ namespace NewRelic.MAUI.Plugin
     private static Exception _lastFirstChanceException;
 #endif
 
+        // Guards against reporting the same unhandled exception twice when more than one hook
+        // fires for it (on Mono both AppDomain.CurrentDomain.UnhandledException and
+        // ObjCRuntime.Runtime.MarshalManagedException fire for the same iOS exception). (NR-588069)
+        private static Exception _lastReportedException;
+
         // We'll route all unhandled exceptions through this one event.
         public static event UnhandledExceptionEventHandler UnhandledException;
 
@@ -23,19 +28,38 @@ namespace NewRelic.MAUI.Plugin
 
             AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
             {
+                if (args.ExceptionObject is Exception ex)
+                {
+                    if (ReferenceEquals(ex, _lastReportedException))
+                    {
+                        return;
+                    }
+                    _lastReportedException = ex;
+                }
                 UnhandledException?.Invoke(sender, args);
             };
 
 #if IOS || MACCATALYST
 
-        // For iOS and Mac Catalyst
-        // Exceptions will flow through AppDomain.CurrentDomain.UnhandledException,
-        // but we need to set UnwindNativeCode to get it to work correctly. 
-        // 
+        // For iOS and Mac Catalyst:
+        //
+        // On Mono, unhandled exceptions flowed through AppDomain.CurrentDomain.UnhandledException
+        // (we set UnwindNativeCode below to make that work).
         // See: https://github.com/xamarin/xamarin-macios/issues/15252
-        
+        //
+        // Under CoreCLR (.NET 10+), AppDomain.CurrentDomain.UnhandledException no longer fires for
+        // exceptions that unwind through native code, so we also capture the exception here at the
+        // managed->native boundary, where CoreCLR surfaces it (args.Exception is populated). Verified
+        // on-device: for an unhandled managed exception only MarshalManagedException fires, not AppDomain.
+        // See: https://learn.microsoft.com/en-us/dotnet/ios/advanced-concepts/exception-marshaling (NR-588069)
         ObjCRuntime.Runtime.MarshalManagedException += (_, args) =>
         {
+            if (args.Exception is not null && !ReferenceEquals(args.Exception, _lastReportedException))
+            {
+                _lastReportedException = args.Exception;
+                UnhandledException?.Invoke(null, new UnhandledExceptionEventArgs(args.Exception, true));
+            }
+
             args.ExceptionMode = ObjCRuntime.MarshalManagedExceptionMode.UnwindNativeCode;
         };
 

--- a/NewRelic.MAUI.iOS.Binding/NewRelic.MAUI.iOS.Binding.csproj
+++ b/NewRelic.MAUI.iOS.Binding/NewRelic.MAUI.iOS.Binding.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net9.0-ios;net10.0-ios</TargetFrameworks>
+		<TargetFrameworks>net10.0-ios;net11.0-ios</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>true</ImplicitUsings>
 		<PackageId>NewRelic.MAUI.iOS.Binding</PackageId>

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This plugin allows you to instrument .NET MAUI mobile apps with help of native N
 ## Current Support:
 
 This project targets .NET MAUI mobile apps and supports .NET MAUI [minimum supported platforms](https://learn.microsoft.com/en-us/dotnet/maui/supported-platforms):
+- Requires .NET 10 (LTS) or higher — the .NET 9 (STS) targets have been dropped
 - Android 7.0 (API 24) or higher
 - iOS 16 or higher, using the latest release of Xcode
 - Depends on New Relic iOS/XCFramework and Android agents


### PR DESCRIPTION
## ⚠️ DRAFT — hold until .NET 11 GA (**November 10, 2026**; STS, still in preview)

Single integration branch for the net11 / CoreCLR cutover. Combines staged, interdependent changes that all gate on net11 GA. **Supersedes #84, #85, #86.** Tracked by **NR-587401** (the open cutover ticket).

## What's included
- **NR-587400** — drop net9 TFMs; plugin + bindings + tests now target **net10 (LTS) + net11**. (net11 bindings via temporary `ProjectReference`; net11 `Maui.Controls` preview.)
- **NR-588069** — iOS unhandled-exception capture under CoreCLR (`ObjCRuntime.Runtime.MarshalManagedException` boundary + `ReferenceEquals` dedup). Verified real-device Release (iPhone18,3 / iOS 26.2.1 → staging `MobileHandledException` with managed context).
- **NR-587402** — `release.yml`: install net10 + net11 SDKs, select **Xcode 26.5**, **JDK 17** (not 21 — see below), Android API 37.

## ⚠️ Known issue found during verification: JDK 21 breaks the Android agent under CoreCLR

While confirming the Android unhandled-exception path parallels the iOS fix, found that the **Android agent fails to start entirely** under CoreCLR when built with **JDK 21**:
```
ArgumentException: Could not determine Java type corresponding to
`Com.Newrelic.Agent.Android.Util.NetworkFailure, ...` (Parameter 'targetType')
   at NewRelic.MAUI.Plugin.NewRelicMethodsImplementation..ctor
   at NewRelic.MAUI.Plugin.CrossNewRelic.get_Current
```
Isolated by on-device A/B (same SDK/TFM/emulator, only JDK changed):

| JDK | Runtime | Result |
|---|---|---|
| 17 | CoreCLR (default) | ✅ works |
| **21** | **CoreCLR** | 🔴 **agent never starts** |
| 21 | Mono (`UseMonoRuntime=true`) | ✅ works |

JDK 21 clears the cosmetic `XA0033` warning but breaks Java.Interop's bound-enum type resolution under CoreCLR; JDK 17 keeps the cosmetic warning but the agent runs correctly. This PR pins CI to **JDK 17** accordingly. Likely an upstream `.NET-for-Android`/Java.Interop preview-SDK bug — worth reporting upstream in addition to internal tracking.

Also found: `AndroidEnvironment.UnhandledExceptionRaiser` **and** `AppDomain.UnhandledException` both fire on Android (on **both** Mono and CoreCLR — not CoreCLR-specific), causing a double-report. Pre-existing bug, not a net11 regression; not yet fixed in this PR.

## Deferred to GA — runbook (the NR-587401 steps that can't be staged yet)
1. **Bump pins to GA:** net11 `Maui.Controls` preview → GA; `DOTNET_VERSION_NET11` → GA SDK; confirm Xcode/JDK requirements for the GA workloads (re-check the JDK 17/21 issue against the GA Android tooling — it may be fixed by then).
2. **Publish** the net11 binding NuGet packages via the release pipeline (prerelease first if desired).
3. **Flip** the plugin's net11 targets from `ProjectReference` → `PackageReference` against the published packages; rebuild net11 → confirm clean restore.
4. **Verify:** CI builds/packs net11 iOS + Android (no `XA0033` blocker, no Xcode mismatch); net11 app reports to NR on both platforms; the 588069 fix on a net11 build; **Android agent actually starts** (this JDK issue would build clean but fail at runtime — needs a real device/emulator check, not just a green build).
5. **Release** the plugin with net11 support.

**Not verifiable green until** hosted runners carry the net11 GA SDK + required Xcode.

Jira: NR-587401 (cutover) · NR-587400 · NR-587402 · NR-588069

🤖 Generated with [Claude Code](https://claude.com/claude-code)
