### PR TITLE
[MAUI] Fix Android unhandled exceptions being reported twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Bug Fixes
 
-- Fixed Android unhandled exceptions being recorded twice as handled exceptions. `Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser` and `AppDomain.CurrentDomain.UnhandledException` both fire for the same unhandled exception; the plugin now dedupes so it is only reported once.
+- Fixed a latent double-report path for Android unhandled exceptions. `Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser` and `AppDomain.CurrentDomain.UnhandledException` both fire for the same unhandled exception, so the plugin's shared event invoked `RecordException` twice. In practice this was usually masked by a race at process teardown (the fatal exception typically kills the process before the second call can persist, so only one `MobileHandledException` was usually recorded) — but that's not guaranteed, so the plugin now dedupes explicitly instead of relying on timing.
 
 # 1.2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Unreleased
+
+## Bug Fixes
+
+- Fixed Android unhandled exceptions being recorded twice as handled exceptions. `Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser` and `AppDomain.CurrentDomain.UnhandledException` both fire for the same unhandled exception; the plugin now dedupes so it is only reported once.
+
 # 1.2.4
 
 ## Improvements

--- a/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
+++ b/NewRelic.MAUI.Plugin/Shared/MauiExceptions.cs
@@ -12,6 +12,12 @@ namespace NewRelic.MAUI.Plugin
     private static Exception _lastFirstChanceException;
 #endif
 
+        // Guards against reporting the same unhandled exception twice when more than one hook
+        // fires for it. On Android, AppDomain.CurrentDomain.UnhandledException and
+        // AndroidEnvironment.UnhandledExceptionRaiser both fire for the same exception (confirmed
+        // on-device on both MonoVM and CoreCLR) — without this guard, RecordException runs twice.
+        private static Exception _lastReportedException;
+
         // We'll route all unhandled exceptions through this one event.
         public static event UnhandledExceptionEventHandler UnhandledException;
 
@@ -23,6 +29,14 @@ namespace NewRelic.MAUI.Plugin
 
             AppDomain.CurrentDomain.UnhandledException += (sender, args) =>
             {
+                if (args.ExceptionObject is Exception ex)
+                {
+                    if (ReferenceEquals(ex, _lastReportedException))
+                    {
+                        return;
+                    }
+                    _lastReportedException = ex;
+                }
                 UnhandledException?.Invoke(sender, args);
             };
 
@@ -42,12 +56,18 @@ namespace NewRelic.MAUI.Plugin
 #elif ANDROID
 
         // For Android:
-        // All exceptions will flow through Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser,
-        // and NOT through AppDomain.CurrentDomain.UnhandledException
+        // Exceptions flow through Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser.
+        // AppDomain.CurrentDomain.UnhandledException also fires for the same exception (confirmed
+        // on-device on both MonoVM and CoreCLR), so guard against double-reporting via the shared
+        // _lastReportedException check above.
 
         global::Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, args) =>
         {
-            UnhandledException?.Invoke(sender, new UnhandledExceptionEventArgs(args.Exception, true));
+            if (args.Exception is not null && !ReferenceEquals(args.Exception, _lastReportedException))
+            {
+                _lastReportedException = args.Exception;
+                UnhandledException?.Invoke(sender, new UnhandledExceptionEventArgs(args.Exception, true));
+            }
         };
 
 #elif WINDOWS


### PR DESCRIPTION
## Summary

`Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser` and `AppDomain.CurrentDomain.UnhandledException` both fire for the same unhandled exception on Android — confirmed on-device on **both MonoVM and CoreCLR**, via local instrumentation (a counter on the plugin's shared event). The plugin's `HandleUncaughtException` → `RecordException` path ran once per hook, so the shared event invoked `RecordException` twice for one exception.

**Real-world impact is smaller than it sounds, and this is worth being precise about (verified against actual staging data, not just local logs):** the exception is fatal, so the process is usually dying by the time the second call tries to persist. In 2/2 clean on-device trials (net10.0-android/Mono, agent started normally, deliberate throw), the local event fired twice but only **one** `MobileHandledException` ever reached staging — the second attempt lost the race against process teardown. So today this is a **latent** bug, not one that's visibly duplicating crash counts for customers right now. But relying on that race is fragile — it's not guaranteed across devices/timing/future native-SDK changes to how `RecordException` persists — so it's worth fixing explicitly rather than depending on luck.

Not net11-specific — reproduces on both Mono and CoreCLR. Found while verifying Android parity for NR-588069 (the iOS CoreCLR exception-capture fix), which already has this exact dedup pattern for iOS/Mac Catalyst. This applies the same guard to Android.

## Change
- `Shared/MauiExceptions.cs`: the Android `AndroidEnvironment.UnhandledExceptionRaiser` handler now checks/sets the shared `_lastReportedException` guard before invoking, same as the iOS handler.

## Verification
**Local event-layer** (net11.0-android, CoreCLR, JDK 17 — chosen as a known-good config; the fix is runtime-agnostic):

| | Before | After |
|---|---|---|
| Local event fires for one unhandled exception | 2 | 1 |

**Staging data-layer** (net10.0-android, Mono, 2 independent clean trials, unique marker per trial, pre-fix code): local event fired twice both times; staging showed exactly **1** `MobileHandledException` both times (teardown race, as above) — confirming the fix removes a latent race rather than a currently-visible duplication.

Also compile-verified on the current shipping targets (`net10.0-android`, `net10.0-ios`) with the stable .NET 10 SDK — 0 errors.

Not tied to net11 — safe to merge independently of the GA cutover (#87).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
