### PR TITLE
[MAUI] Publish symbol packages (.snupkg) for plugin and bindings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,21 +139,30 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: android-binding-nupkg
-          path: NewRelic.MAUI.Android.Binding/bin/Release/*.nupkg
+          # Both patterns are listed explicitly: *.nupkg does not match
+          # *.snupkg, and the symbol package is only on disk for the life of
+          # the runner (dotnet nuget push forwards it to nuget.org directly).
+          path: |
+            NewRelic.MAUI.Android.Binding/bin/Release/*.nupkg
+            NewRelic.MAUI.Android.Binding/bin/Release/*.snupkg
 
       - name: Upload iOS artifact
         if: ${{ needs.parse-tag.outputs.ios_version != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: ios-binding-nupkg
-          path: NewRelic.MAUI.iOS.Binding/bin/Release/*.nupkg
+          path: |
+            NewRelic.MAUI.iOS.Binding/bin/Release/*.nupkg
+            NewRelic.MAUI.iOS.Binding/bin/Release/*.snupkg
 
       - name: Upload plugin artifact
         if: ${{ needs.parse-tag.outputs.plugin_version != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: plugin-nupkg
-          path: NewRelic.MAUI.Plugin/bin/Release/*.nupkg
+          path: |
+            NewRelic.MAUI.Plugin/bin/Release/*.nupkg
+            NewRelic.MAUI.Plugin/bin/Release/*.snupkg
 
   create-release:
     needs: [parse-tag, release]
@@ -173,7 +182,9 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          files: artifacts/**/*.nupkg
+          files: |
+            artifacts/**/*.nupkg
+            artifacts/**/*.snupkg
           generate_release_notes: true
           draft: false
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # Unreleased
 
+## Improvements
+
+- Symbol packages (`.snupkg`) are now published alongside the NuGet packages for `NewRelic.MAUI.Plugin`, `NewRelic.MAUI.iOS.Binding`, and `NewRelic.MAUI.Android.Binding`. Each contains the portable PDBs for every target framework the package ships, so stack frames that resolve into plugin or binding code can be symbolicated.
+
 ## Bug Fixes
 
 - Fixed a latent double-report path for Android unhandled exceptions. `Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser` and `AppDomain.CurrentDomain.UnhandledException` both fire for the same unhandled exception, so the plugin's shared event invoked `RecordException` twice. In practice this was usually masked by a race at process teardown (the fatal exception typically kills the process before the second call can persist, so only one `MobileHandledException` was usually recorded) — but that's not guaranteed, so the plugin now dedupes explicitly instead of relying on timing.

--- a/NewRelic.MAUI.Android.Binding/NewRelic.MAUI.Android.Binding.csproj
+++ b/NewRelic.MAUI.Android.Binding/NewRelic.MAUI.Android.Binding.csproj
@@ -18,6 +18,11 @@
 		<PackageTags>newrelic;MAUI;android;new relic;observability;monitoring;telemetry</PackageTags>
 		<Version>7.7.7</Version>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<!-- Ship a symbol package alongside the .nupkg so frames in this
+		     assembly can be symbolicated. See the note in
+		     NewRelic.MAUI.Plugin.csproj on same-build PDB/DLL matching. -->
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 	<ItemGroup>
 		<TransformFile Include="Transforms\Metadata.xml" />

--- a/NewRelic.MAUI.Plugin/NewRelic.MAUI.Plugin.csproj
+++ b/NewRelic.MAUI.Plugin/NewRelic.MAUI.Plugin.csproj
@@ -17,6 +17,13 @@
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>newrelic;new relic;MAUI;mobile;monitoring;instrumentation;android;iOS</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<!-- Ship a symbol package alongside the .nupkg so frames in this
+		     assembly can be symbolicated. The PDBs here must come from the
+		     same build as the DLLs in the .nupkg (they are matched by MVID),
+		     which is why packing happens on build rather than as a separate
+		     step. -->
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageProjectUrl>https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-maui-dotnet/monitor-your-net-maui-application/</PackageProjectUrl>
 		<SynchReleaseVersion>false</SynchReleaseVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>

--- a/NewRelic.MAUI.iOS.Binding/NewRelic.MAUI.iOS.Binding.csproj
+++ b/NewRelic.MAUI.iOS.Binding/NewRelic.MAUI.iOS.Binding.csproj
@@ -16,6 +16,11 @@
 		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
 		<PackageTags>newrelic;MAUI;iOS;new relic;observability;monitoring;telemetry</PackageTags>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<!-- Ship a symbol package alongside the .nupkg so frames in this
+		     assembly can be symbolicated. See the note in
+		     NewRelic.MAUI.Plugin.csproj on same-build PDB/DLL matching. -->
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 	<ItemGroup>
 		<ObjcBindingApiDefinition Include="ApiDefinition.cs" />


### PR DESCRIPTION
**Ticket:** [NR-598358](https://new-relic.atlassian.net/browse/NR-598358)

## What & Why

None of the three published packages — `NewRelic.MAUI.Plugin`, `NewRelic.MAUI.iOS.Binding`, `NewRelic.MAUI.Android.Binding` — have ever shipped a symbol package. Any crash frame that resolves into `NewRelic.MAUI.*` code therefore can't be symbolicated by anyone: no PDB exists anywhere to match against, publicly or privately.

This matters now because of the MAUI symbolication work ([POC](https://source.datanerd.us/mobile/shared-component-stack-trace-attributes-table/pull/79)). That flow needs a **matching `.pdb` and `.dll` pair** — a Portable PDB needs the DLL for name→token resolution before the PDB can be looked up. The DLLs are already public inside each `.nupkg`; the PDBs were the missing half.

Note the POC is fully client-side ad-hoc upload — there is no symbol store and nothing fetches from nuget.org automatically. So this change doesn't make NR-frame symbolication automatic; it makes the PDB *obtainable at all*, which is the prerequisite.

## Changes

- `IncludeSymbols` + `SymbolPackageFormat=snupkg` on the three published projects. `NewRelic.MAUI.Plugin.Tests` is untouched — never packed or published.
- Widened the release workflow's four artifact globs. They used `*.nupkg`, which does **not** match `*.snupkg` (the glob needs a literal `.nupkg`), so symbols were silently excluded from CI artifacts and tag-push GitHub Releases.
- CHANGELOG entry under Unreleased.

**No changes to `scripts/release.sh`.** `publish_package()` finds the `.nupkg` and `dotnet nuget push` auto-forwards a same-named sibling `.snupkg` from the same directory unless `--no-symbols` is passed.

## Callouts

**Packages must keep being produced by a single build.** PDBs and DLLs are matched by MVID, so they have to come from the same compilation. `GeneratePackageOnBuild` already guarantees this — splitting build and pack, or rebuilding between pack and push, would silently break symbolication while still producing valid-looking packages. There's a comment in `NewRelic.MAUI.Plugin.csproj` to that effect.

## Testing

All three projects built with `dotnet build -c Release` (the exact command `build_package()` runs). All build clean, `0 Error(s)`, and each emits a `.snupkg`:

| Package | PDBs in snupkg |
|---|---|
| `NewRelic.MAUI.Android.Binding` 7.7.7 | 2 TFMs |
| `NewRelic.MAUI.iOS.Binding` 7.7.3 | 2 TFMs |
| `NewRelic.MAUI.Plugin` 1.2.5 | 6 TFMs |

A file existing isn't sufficient — a PDB that doesn't match its DLL is useless. For all 10 assemblies I confirmed the PDB is portable format (`BSJB`) and parsed the DLL's CodeView debug directory out of the `.nupkg` to confirm its GUID is present in the corresponding `.snupkg` PDB. **10/10 match.**

Also simulated the reworked workflow globs against the real build output; each now picks up both files, and the YAML parses.

## Verification after release

⚠️ **The acceptance criterion in the ticket is wrong** — I've commented there with details. Checking the flat-container URL for a `.snupkg` can never return 200: `api.nuget.org/v3-flatcontainer` serves only `.nupkg` and `.nuspec`. Confirmed with a positive control — Serilog's symbols are demonstrably retrievable, yet its flat-container `.snupkg` URL 404s.

Verify with `dotnet-symbol` instead:

```bash
dotnet tool install -g dotnet-symbol
dotnet-symbol --symbols --server-path https://symbols.nuget.org/download/symbols \
    --output ./out  path/to/NewRelic.MAUI.Plugin.dll
```

Because the lookup key *is* the DLL's debug GUID, a successful retrieval inherently proves the PDB matches the shipped DLL. Symbol validation on nuget.org is asynchronous, so allow time after the push before concluding failure — a rejection arrives by email, not as a failed release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[NR-598358]: https://new-relic.atlassian.net/browse/NR-598358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ